### PR TITLE
Make the root identifier optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An exploration of JSONPath parsing and evaluation in Rust with Python bindings i
 - `crates/jsonpath_rfc9535_serde` implements JSONPath evaluation using Serde JSON, based on the pest parser.
 - `crates/jsonpath_rfc9535_iter` is an experimental lazily evaluated implementation of JSONPath.
 - `crates/jsonpath_rfc9535_locations` is not lazily evaluated, but uses persistent linked lists to build node locations. It outperforms the naive Serde JSON and iterator-based implementations both in execution speed and memory usage, and "feels" much cleaner than the iterator implementation.
-- `crates/jsonpath_rfc9535_singular` is a "fork" of `crates/jsonpath_rfc9535_locations` with a non-standard _singular query selector_.
+- `crates/jsonpath_rfc9535_singular` is a "fork" of `crates/jsonpath_rfc9535_locations` with a non-standard _singular query selector_ and _implicit root identifier_.
 
 ## Hand-crafted parser
 

--- a/crates/jsonpath_rfc9535_iter/src/lib.rs
+++ b/crates/jsonpath_rfc9535_iter/src/lib.rs
@@ -10,6 +10,7 @@ pub mod query;
 pub mod segment;
 pub mod selector;
 pub mod standard_functions;
+mod unescape;
 
 pub use jsonpath::find;
 pub use parser::JSONPathParser;

--- a/crates/jsonpath_rfc9535_iter/src/parser.rs
+++ b/crates/jsonpath_rfc9535_iter/src/parser.rs
@@ -17,6 +17,7 @@ use crate::{
     query::Query,
     segment::Segment,
     selector::Selector,
+    unescape::unescape,
 };
 
 #[derive(Parser)]
@@ -90,10 +91,10 @@ impl JSONPathParser {
     fn parse_selector(&self, selector: Pair<Rule>) -> Result<Selector, JSONPathError> {
         Ok(match selector.as_rule() {
             Rule::double_quoted => Selector::Name {
-                name: unescape_string(selector.as_str()),
+                name: unescape(selector.as_str())?,
             },
             Rule::single_quoted => Selector::Name {
-                name: unescape_string(&selector.as_str().replace("\\'", "'")),
+                name: unescape(&selector.as_str().replace("\\'", "'"))?,
             },
             Rule::wildcard_selector => Selector::Wild,
             Rule::slice_selector => self.parse_slice_selector(selector)?,
@@ -243,10 +244,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -394,10 +395,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -607,71 +608,6 @@ impl JSONPathParser {
             _ => false,
         }
     }
-}
-
-fn unescape_string(value: &str) -> String {
-    let chars = value.chars().collect::<Vec<char>>();
-    let length = chars.len();
-    let mut rv = String::new();
-    let mut index: usize = 0;
-
-    while index < length {
-        match chars[index] {
-            '\\' => {
-                index += 1;
-
-                match chars[index] {
-                    '"' => rv.push('"'),
-                    '\\' => rv.push('\\'),
-                    '/' => rv.push('/'),
-                    'b' => rv.push('\x08'),
-                    'f' => rv.push('\x0C'),
-                    'n' => rv.push('\n'),
-                    'r' => rv.push('\r'),
-                    't' => rv.push('\t'),
-                    'u' => {
-                        index += 1;
-
-                        let digits = chars
-                            .get(index..index + 4)
-                            .unwrap()
-                            .iter()
-                            .collect::<String>();
-
-                        let mut codepoint = u32::from_str_radix(&digits, 16).unwrap();
-
-                        if index + 5 < length && chars[index + 4] == '\\' && chars[index + 5] == 'u'
-                        {
-                            let digits = &chars
-                                .get(index + 6..index + 10)
-                                .unwrap()
-                                .iter()
-                                .collect::<String>();
-
-                            let low_surrogate = u32::from_str_radix(digits, 16).unwrap();
-
-                            codepoint =
-                                0x10000 + (((codepoint & 0x03FF) << 10) | (low_surrogate & 0x03FF));
-
-                            index += 6;
-                        }
-
-                        let unescaped = char::from_u32(codepoint).unwrap();
-                        rv.push(unescaped);
-                        index += 3;
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            c => {
-                rv.push(c);
-            }
-        }
-
-        index += 1;
-    }
-
-    rv
 }
 
 #[cfg(test)]

--- a/crates/jsonpath_rfc9535_iter/src/unescape.rs
+++ b/crates/jsonpath_rfc9535_iter/src/unescape.rs
@@ -1,0 +1,103 @@
+use core::str;
+
+use crate::errors::JSONPathError;
+
+pub fn unescape(value: &str) -> Result<String, JSONPathError> {
+    let bytes = value.as_bytes();
+    let length = bytes.len();
+    let mut rv: Vec<u8> = Vec::new();
+    let mut index: usize = 0;
+    let mut code_point: u32;
+
+    while index < length {
+        let b = bytes[index];
+        if b == b'\\' {
+            index += 1;
+            match bytes[index] {
+                b'"' => rv.push(b'"'),
+                b'\\' => rv.push(b'\\'),
+                b'/' => rv.push(b'/'),
+                b'b' => rv.push(b'\x08'),
+                b'f' => rv.push(b'\x0C'),
+                b'n' => rv.push(b'\n'),
+                b'r' => rv.push(b'\r'),
+                b't' => rv.push(b'\t'),
+                b'u' => {
+                    (code_point, index) = decode_hex_char(bytes, index)?;
+                    let mut x = encode_code_point(code_point)?;
+                    rv.append(&mut x);
+                }
+                _ => return Err(JSONPathError::syntax("unknown escape sequence".to_owned())),
+            }
+        } else {
+            rv.push(b);
+        }
+        index += 1;
+    }
+
+    return Ok(String::from_utf8(rv).unwrap());
+}
+
+fn decode_hex_char(bytes: &[u8], index: usize) -> Result<(u32, usize), JSONPathError> {
+    let length = bytes.len();
+    let mut index = index;
+
+    if index + 4 >= length {
+        return Err(JSONPathError::syntax(
+            "incomplete escape sequence".to_owned(),
+        ));
+    }
+
+    index = index + 1; // move past 'u'
+    let mut code_point = parse_hex_digits(&bytes[index..index + 4])?;
+
+    if is_low_surrogate(code_point) {
+        return Err(JSONPathError::syntax(
+            "unexpected low surrogate code point".to_owned(),
+        ));
+    }
+
+    if is_high_surrogate(code_point) {
+        if !(index + 9 < length && bytes[index + 4] == b'\\' && bytes[index + 5] == b'u') {
+            return Err(JSONPathError::syntax(
+                "incomplete escape sequence".to_owned(),
+            ));
+        }
+
+        let low_surrogate = parse_hex_digits(&bytes[index + 6..index + 10])?;
+
+        if !is_low_surrogate(low_surrogate) {
+            return Err(JSONPathError::syntax("unexpected code point".to_owned()));
+        }
+
+        code_point = 0x10000 + (((code_point & 0x03FF) << 10) | (low_surrogate & 0x03FF));
+        return Ok((code_point, index + 9));
+    }
+
+    Ok((code_point, index + 3))
+}
+
+fn parse_hex_digits(digits: &[u8]) -> Result<u32, JSONPathError> {
+    let s = str::from_utf8(digits).unwrap();
+    u32::from_str_radix(s, 16)
+        .map_err(|_| JSONPathError::syntax("invalid escape sequence".to_owned()))
+}
+
+fn encode_code_point(code_point: u32) -> Result<Vec<u8>, JSONPathError> {
+    if code_point < 0x1F {
+        Err(JSONPathError::syntax("invalid character".to_owned()))
+    } else {
+        // TODO: better
+        let mut buf = [0; 4];
+        let rv = char::from_u32(code_point).unwrap().encode_utf8(&mut buf);
+        Ok(rv.as_bytes().to_owned())
+    }
+}
+
+fn is_high_surrogate(code_point: u32) -> bool {
+    code_point >= 0xD800 && code_point <= 0xDBFF
+}
+
+fn is_low_surrogate(code_point: u32) -> bool {
+    code_point >= 0xDC00 && code_point <= 0xDFFF
+}

--- a/crates/jsonpath_rfc9535_locations/src/lib.rs
+++ b/crates/jsonpath_rfc9535_locations/src/lib.rs
@@ -10,6 +10,7 @@ pub mod query;
 mod segment;
 mod selector;
 pub mod standard_functions;
+mod unescape;
 
 pub use jsonpath::find;
 pub use jsonpath::ENV;

--- a/crates/jsonpath_rfc9535_locations/src/parser.rs
+++ b/crates/jsonpath_rfc9535_locations/src/parser.rs
@@ -17,6 +17,7 @@ use crate::{
     query::Query,
     segment::Segment,
     selector::Selector,
+    unescape::unescape,
 };
 
 #[derive(Parser)]
@@ -90,10 +91,10 @@ impl JSONPathParser {
     fn parse_selector(&self, selector: Pair<Rule>) -> Result<Selector, JSONPathError> {
         Ok(match selector.as_rule() {
             Rule::double_quoted => Selector::Name {
-                name: unescape_string(selector.as_str()),
+                name: unescape(selector.as_str())?,
             },
             Rule::single_quoted => Selector::Name {
-                name: unescape_string(&selector.as_str().replace("\\'", "'")),
+                name: unescape(&selector.as_str().replace("\\'", "'"))?,
             },
             Rule::wildcard_selector => Selector::Wild,
             Rule::slice_selector => self.parse_slice_selector(selector)?,
@@ -243,10 +244,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -394,10 +395,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -607,71 +608,6 @@ impl JSONPathParser {
             _ => false,
         }
     }
-}
-
-fn unescape_string(value: &str) -> String {
-    let chars = value.chars().collect::<Vec<char>>();
-    let length = chars.len();
-    let mut rv = String::new();
-    let mut index: usize = 0;
-
-    while index < length {
-        match chars[index] {
-            '\\' => {
-                index += 1;
-
-                match chars[index] {
-                    '"' => rv.push('"'),
-                    '\\' => rv.push('\\'),
-                    '/' => rv.push('/'),
-                    'b' => rv.push('\x08'),
-                    'f' => rv.push('\x0C'),
-                    'n' => rv.push('\n'),
-                    'r' => rv.push('\r'),
-                    't' => rv.push('\t'),
-                    'u' => {
-                        index += 1;
-
-                        let digits = chars
-                            .get(index..index + 4)
-                            .unwrap()
-                            .iter()
-                            .collect::<String>();
-
-                        let mut codepoint = u32::from_str_radix(&digits, 16).unwrap();
-
-                        if index + 5 < length && chars[index + 4] == '\\' && chars[index + 5] == 'u'
-                        {
-                            let digits = &chars
-                                .get(index + 6..index + 10)
-                                .unwrap()
-                                .iter()
-                                .collect::<String>();
-
-                            let low_surrogate = u32::from_str_radix(digits, 16).unwrap();
-
-                            codepoint =
-                                0x10000 + (((codepoint & 0x03FF) << 10) | (low_surrogate & 0x03FF));
-
-                            index += 6;
-                        }
-
-                        let unescaped = char::from_u32(codepoint).unwrap();
-                        rv.push(unescaped);
-                        index += 3;
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            c => {
-                rv.push(c);
-            }
-        }
-
-        index += 1;
-    }
-
-    rv
 }
 
 #[cfg(test)]

--- a/crates/jsonpath_rfc9535_locations/src/unescape.rs
+++ b/crates/jsonpath_rfc9535_locations/src/unescape.rs
@@ -1,0 +1,103 @@
+use core::str;
+
+use crate::errors::JSONPathError;
+
+pub fn unescape(value: &str) -> Result<String, JSONPathError> {
+    let bytes = value.as_bytes();
+    let length = bytes.len();
+    let mut rv: Vec<u8> = Vec::new();
+    let mut index: usize = 0;
+    let mut code_point: u32;
+
+    while index < length {
+        let b = bytes[index];
+        if b == b'\\' {
+            index += 1;
+            match bytes[index] {
+                b'"' => rv.push(b'"'),
+                b'\\' => rv.push(b'\\'),
+                b'/' => rv.push(b'/'),
+                b'b' => rv.push(b'\x08'),
+                b'f' => rv.push(b'\x0C'),
+                b'n' => rv.push(b'\n'),
+                b'r' => rv.push(b'\r'),
+                b't' => rv.push(b'\t'),
+                b'u' => {
+                    (code_point, index) = decode_hex_char(bytes, index)?;
+                    let mut x = encode_code_point(code_point)?;
+                    rv.append(&mut x);
+                }
+                _ => return Err(JSONPathError::syntax("unknown escape sequence".to_owned())),
+            }
+        } else {
+            rv.push(b);
+        }
+        index += 1;
+    }
+
+    return Ok(String::from_utf8(rv).unwrap());
+}
+
+fn decode_hex_char(bytes: &[u8], index: usize) -> Result<(u32, usize), JSONPathError> {
+    let length = bytes.len();
+    let mut index = index;
+
+    if index + 4 >= length {
+        return Err(JSONPathError::syntax(
+            "incomplete escape sequence".to_owned(),
+        ));
+    }
+
+    index = index + 1; // move past 'u'
+    let mut code_point = parse_hex_digits(&bytes[index..index + 4])?;
+
+    if is_low_surrogate(code_point) {
+        return Err(JSONPathError::syntax(
+            "unexpected low surrogate code point".to_owned(),
+        ));
+    }
+
+    if is_high_surrogate(code_point) {
+        if !(index + 9 < length && bytes[index + 4] == b'\\' && bytes[index + 5] == b'u') {
+            return Err(JSONPathError::syntax(
+                "incomplete escape sequence".to_owned(),
+            ));
+        }
+
+        let low_surrogate = parse_hex_digits(&bytes[index + 6..index + 10])?;
+
+        if !is_low_surrogate(low_surrogate) {
+            return Err(JSONPathError::syntax("unexpected code point".to_owned()));
+        }
+
+        code_point = 0x10000 + (((code_point & 0x03FF) << 10) | (low_surrogate & 0x03FF));
+        return Ok((code_point, index + 9));
+    }
+
+    Ok((code_point, index + 3))
+}
+
+fn parse_hex_digits(digits: &[u8]) -> Result<u32, JSONPathError> {
+    let s = str::from_utf8(digits).unwrap();
+    u32::from_str_radix(s, 16)
+        .map_err(|_| JSONPathError::syntax("invalid escape sequence".to_owned()))
+}
+
+fn encode_code_point(code_point: u32) -> Result<Vec<u8>, JSONPathError> {
+    if code_point < 0x1F {
+        Err(JSONPathError::syntax("invalid character".to_owned()))
+    } else {
+        // TODO: better
+        let mut buf = [0; 4];
+        let rv = char::from_u32(code_point).unwrap().encode_utf8(&mut buf);
+        Ok(rv.as_bytes().to_owned())
+    }
+}
+
+fn is_high_surrogate(code_point: u32) -> bool {
+    code_point >= 0xD800 && code_point <= 0xDBFF
+}
+
+fn is_low_surrogate(code_point: u32) -> bool {
+    code_point >= 0xDC00 && code_point <= 0xDFFF
+}

--- a/crates/jsonpath_rfc9535_serde/src/lib.rs
+++ b/crates/jsonpath_rfc9535_serde/src/lib.rs
@@ -5,6 +5,7 @@ pub mod function;
 pub mod jsonpath;
 pub mod parser;
 pub mod standard_functions;
+mod unescape;
 
 pub use ast::Query;
 pub use jsonpath::find;

--- a/crates/jsonpath_rfc9535_serde/src/unescape.rs
+++ b/crates/jsonpath_rfc9535_serde/src/unescape.rs
@@ -1,0 +1,103 @@
+use core::str;
+
+use crate::errors::JSONPathError;
+
+pub fn unescape(value: &str) -> Result<String, JSONPathError> {
+    let bytes = value.as_bytes();
+    let length = bytes.len();
+    let mut rv: Vec<u8> = Vec::new();
+    let mut index: usize = 0;
+    let mut code_point: u32;
+
+    while index < length {
+        let b = bytes[index];
+        if b == b'\\' {
+            index += 1;
+            match bytes[index] {
+                b'"' => rv.push(b'"'),
+                b'\\' => rv.push(b'\\'),
+                b'/' => rv.push(b'/'),
+                b'b' => rv.push(b'\x08'),
+                b'f' => rv.push(b'\x0C'),
+                b'n' => rv.push(b'\n'),
+                b'r' => rv.push(b'\r'),
+                b't' => rv.push(b'\t'),
+                b'u' => {
+                    (code_point, index) = decode_hex_char(bytes, index)?;
+                    let mut x = encode_code_point(code_point)?;
+                    rv.append(&mut x);
+                }
+                _ => return Err(JSONPathError::syntax("unknown escape sequence".to_owned())),
+            }
+        } else {
+            rv.push(b);
+        }
+        index += 1;
+    }
+
+    return Ok(String::from_utf8(rv).unwrap());
+}
+
+fn decode_hex_char(bytes: &[u8], index: usize) -> Result<(u32, usize), JSONPathError> {
+    let length = bytes.len();
+    let mut index = index;
+
+    if index + 4 >= length {
+        return Err(JSONPathError::syntax(
+            "incomplete escape sequence".to_owned(),
+        ));
+    }
+
+    index = index + 1; // move past 'u'
+    let mut code_point = parse_hex_digits(&bytes[index..index + 4])?;
+
+    if is_low_surrogate(code_point) {
+        return Err(JSONPathError::syntax(
+            "unexpected low surrogate code point".to_owned(),
+        ));
+    }
+
+    if is_high_surrogate(code_point) {
+        if !(index + 9 < length && bytes[index + 4] == b'\\' && bytes[index + 5] == b'u') {
+            return Err(JSONPathError::syntax(
+                "incomplete escape sequence".to_owned(),
+            ));
+        }
+
+        let low_surrogate = parse_hex_digits(&bytes[index + 6..index + 10])?;
+
+        if !is_low_surrogate(low_surrogate) {
+            return Err(JSONPathError::syntax("unexpected code point".to_owned()));
+        }
+
+        code_point = 0x10000 + (((code_point & 0x03FF) << 10) | (low_surrogate & 0x03FF));
+        return Ok((code_point, index + 9));
+    }
+
+    Ok((code_point, index + 3))
+}
+
+fn parse_hex_digits(digits: &[u8]) -> Result<u32, JSONPathError> {
+    let s = str::from_utf8(digits).unwrap();
+    u32::from_str_radix(s, 16)
+        .map_err(|_| JSONPathError::syntax("invalid escape sequence".to_owned()))
+}
+
+fn encode_code_point(code_point: u32) -> Result<Vec<u8>, JSONPathError> {
+    if code_point < 0x1F {
+        Err(JSONPathError::syntax("invalid character".to_owned()))
+    } else {
+        // TODO: better
+        let mut buf = [0; 4];
+        let rv = char::from_u32(code_point).unwrap().encode_utf8(&mut buf);
+        Ok(rv.as_bytes().to_owned())
+    }
+}
+
+fn is_high_surrogate(code_point: u32) -> bool {
+    code_point >= 0xD800 && code_point <= 0xDBFF
+}
+
+fn is_low_surrogate(code_point: u32) -> bool {
+    code_point >= 0xDC00 && code_point <= 0xDFFF
+}

--- a/crates/jsonpath_rfc9535_singular_selector/src/jsonpath.pest
+++ b/crates/jsonpath_rfc9535_singular_selector/src/jsonpath.pest
@@ -1,7 +1,8 @@
-jsonpath = _{ SOI ~ jsonpath_query ~ EOI }
+jsonpath = _{ SOI ~ (jsonpath_query | implicit_root_query) ~ EOI }
 
-jsonpath_query = _{ root_identifier ~ segments }
-segments       = _{ (S ~ segment)* }
+jsonpath_query      = _{ root_identifier ~ segments }
+implicit_root_query = _{ implicit_root_segment ~ segments }
+segments            = _{ (S ~ segment)* }
 
 B = _{ "\x20" | "\x09" | "\x0A" | "\x0D" }
 S = _{ B* }
@@ -85,7 +86,7 @@ filter_selector         =  { "?" ~ S ~ logical_expr }
 logical_expr            = _{ logical_or_expr }
 logical_or_expr         =  { logical_and_expr ~ (S ~ "||" ~ S ~ logical_and_expr)* }
 logical_and_expr        =  { basic_expr ~ (S ~ "&&" ~ S ~ basic_expr)* }
-singular_query_selector =  { root_identifier ~ singular_query_segments }
+singular_query_selector =  { (root_identifier ~ singular_query_segments) | implicit_root_singular_query_segments }
 
 basic_expr = _{
     paren_expr
@@ -128,14 +129,20 @@ comparison_op = {
 // TODO: silencing singular_query and/or singular_query_segments leads to
 // undesirable error messaages.
 
-singular_query          = _{ rel_singular_query | abs_singular_query }
-rel_singular_query      =  { current_node_identifier ~ singular_query_segments }
-abs_singular_query      =  { root_identifier ~ singular_query_segments }
-singular_query_segments = _{ (S ~ (name_segment | index_segment))* }
+singular_query                        = _{ rel_singular_query | abs_singular_query }
+rel_singular_query                    =  { current_node_identifier ~ singular_query_segments }
+abs_singular_query                    =  { root_identifier ~ singular_query_segments }
+singular_query_segments               = _{ (S ~ (name_segment | index_segment))* }
+implicit_root_singular_query_segments = _{ (implicit_root_name_segment | index_segment) ~ singular_query_segments }
 
 name_segment = {
     ("[" ~ name_selector ~ "]")
   | ("." ~ member_name_shorthand)
+}
+
+implicit_root_name_segment = {
+    ("[" ~ name_selector ~ "]")
+  | member_name_shorthand
 }
 
 index_segment       =  { "[" ~ index_selector ~ "]" }
@@ -163,6 +170,11 @@ function_argument = _{
 segment = _{
     child_segment
   | descendant_segment
+}
+
+implicit_root_segment = {
+    bracketed_selection
+  | member_name_shorthand
 }
 
 child_segment = {

--- a/crates/jsonpath_rfc9535_singular_selector/src/lib.rs
+++ b/crates/jsonpath_rfc9535_singular_selector/src/lib.rs
@@ -10,6 +10,7 @@ pub mod query;
 mod segment;
 mod selector;
 pub mod standard_functions;
+mod unescape;
 
 pub use jsonpath::find;
 pub use jsonpath::ENV;

--- a/crates/jsonpath_rfc9535_singular_selector/src/parser.rs
+++ b/crates/jsonpath_rfc9535_singular_selector/src/parser.rs
@@ -17,6 +17,7 @@ use crate::{
     query::Query,
     segment::Segment,
     selector::Selector,
+    unescape::unescape,
 };
 
 #[derive(Parser)]
@@ -90,10 +91,10 @@ impl JSONPathParser {
     fn parse_selector(&self, selector: Pair<Rule>) -> Result<Selector, JSONPathError> {
         Ok(match selector.as_rule() {
             Rule::double_quoted => Selector::Name {
-                name: unescape_string(selector.as_str()),
+                name: unescape(selector.as_str())?,
             },
             Rule::single_quoted => Selector::Name {
-                name: unescape_string(&selector.as_str().replace("\\'", "'")),
+                name: unescape(&selector.as_str().replace("\\'", "'"))?,
             },
             Rule::wildcard_selector => Selector::Wild,
             Rule::slice_selector => self.parse_slice_selector(selector)?,
@@ -260,10 +261,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -411,10 +412,10 @@ impl JSONPathParser {
         Ok(match expr.as_rule() {
             Rule::number => self.parse_number(expr)?,
             Rule::double_quoted => FilterExpression::String {
-                value: unescape_string(expr.as_str()),
+                value: unescape(expr.as_str())?,
             },
             Rule::single_quoted => FilterExpression::String {
-                value: unescape_string(&expr.as_str().replace("\\'", "'")),
+                value: unescape(&expr.as_str().replace("\\'", "'"))?,
             },
             Rule::true_literal => FilterExpression::True,
             Rule::false_literal => FilterExpression::False,
@@ -624,71 +625,6 @@ impl JSONPathParser {
             _ => false,
         }
     }
-}
-
-fn unescape_string(value: &str) -> String {
-    let chars = value.chars().collect::<Vec<char>>();
-    let length = chars.len();
-    let mut rv = String::new();
-    let mut index: usize = 0;
-
-    while index < length {
-        match chars[index] {
-            '\\' => {
-                index += 1;
-
-                match chars[index] {
-                    '"' => rv.push('"'),
-                    '\\' => rv.push('\\'),
-                    '/' => rv.push('/'),
-                    'b' => rv.push('\x08'),
-                    'f' => rv.push('\x0C'),
-                    'n' => rv.push('\n'),
-                    'r' => rv.push('\r'),
-                    't' => rv.push('\t'),
-                    'u' => {
-                        index += 1;
-
-                        let digits = chars
-                            .get(index..index + 4)
-                            .unwrap()
-                            .iter()
-                            .collect::<String>();
-
-                        let mut codepoint = u32::from_str_radix(&digits, 16).unwrap();
-
-                        if index + 5 < length && chars[index + 4] == '\\' && chars[index + 5] == 'u'
-                        {
-                            let digits = &chars
-                                .get(index + 6..index + 10)
-                                .unwrap()
-                                .iter()
-                                .collect::<String>();
-
-                            let low_surrogate = u32::from_str_radix(digits, 16).unwrap();
-
-                            codepoint =
-                                0x10000 + (((codepoint & 0x03FF) << 10) | (low_surrogate & 0x03FF));
-
-                            index += 6;
-                        }
-
-                        let unescaped = char::from_u32(codepoint).unwrap();
-                        rv.push(unescaped);
-                        index += 3;
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            c => {
-                rv.push(c);
-            }
-        }
-
-        index += 1;
-    }
-
-    rv
 }
 
 #[cfg(test)]

--- a/crates/jsonpath_rfc9535_singular_selector/src/parser.rs
+++ b/crates/jsonpath_rfc9535_singular_selector/src/parser.rs
@@ -56,17 +56,19 @@ impl JSONPathParser {
 
     fn parse_segment(&self, segment: Pair<Rule>) -> Result<Segment, JSONPathError> {
         Ok(match segment.as_rule() {
-            Rule::child_segment => Segment::Child {
+            Rule::child_segment | Rule::implicit_root_segment => Segment::Child {
                 selectors: self.parse_segment_inner(segment.into_inner().next().unwrap())?,
             },
             Rule::descendant_segment => Segment::Recursive {
                 selectors: self.parse_segment_inner(segment.into_inner().next().unwrap())?,
             },
-            Rule::name_segment | Rule::index_segment => Segment::Child {
-                selectors: vec![self.parse_selector(segment.into_inner().next().unwrap())?],
-            },
+            Rule::name_segment | Rule::index_segment | Rule::implicit_root_name_segment => {
+                Segment::Child {
+                    selectors: vec![self.parse_selector(segment.into_inner().next().unwrap())?],
+                }
+            }
             Rule::EOI => Segment::Eoi,
-            _ => unreachable!(),
+            _ => unreachable!("{:#?}", segment),
         })
     }
 
@@ -107,7 +109,7 @@ impl JSONPathParser {
                 name: selector.as_str().to_owned(),
             },
             Rule::singular_query_selector => self.parse_singular_query_selector(selector)?,
-            _ => unreachable!(),
+            _ => unreachable!("{:#?}", selector),
         })
     }
 

--- a/crates/jsonpath_rfc9535_singular_selector/src/unescape.rs
+++ b/crates/jsonpath_rfc9535_singular_selector/src/unescape.rs
@@ -1,0 +1,103 @@
+use core::str;
+
+use crate::errors::JSONPathError;
+
+pub fn unescape(value: &str) -> Result<String, JSONPathError> {
+    let bytes = value.as_bytes();
+    let length = bytes.len();
+    let mut rv: Vec<u8> = Vec::new();
+    let mut index: usize = 0;
+    let mut code_point: u32;
+
+    while index < length {
+        let b = bytes[index];
+        if b == b'\\' {
+            index += 1;
+            match bytes[index] {
+                b'"' => rv.push(b'"'),
+                b'\\' => rv.push(b'\\'),
+                b'/' => rv.push(b'/'),
+                b'b' => rv.push(b'\x08'),
+                b'f' => rv.push(b'\x0C'),
+                b'n' => rv.push(b'\n'),
+                b'r' => rv.push(b'\r'),
+                b't' => rv.push(b'\t'),
+                b'u' => {
+                    (code_point, index) = decode_hex_char(bytes, index)?;
+                    let mut x = encode_code_point(code_point)?;
+                    rv.append(&mut x);
+                }
+                _ => return Err(JSONPathError::syntax("unknown escape sequence".to_owned())),
+            }
+        } else {
+            rv.push(b);
+        }
+        index += 1;
+    }
+
+    return Ok(String::from_utf8(rv).unwrap());
+}
+
+fn decode_hex_char(bytes: &[u8], index: usize) -> Result<(u32, usize), JSONPathError> {
+    let length = bytes.len();
+    let mut index = index;
+
+    if index + 4 >= length {
+        return Err(JSONPathError::syntax(
+            "incomplete escape sequence".to_owned(),
+        ));
+    }
+
+    index = index + 1; // move past 'u'
+    let mut code_point = parse_hex_digits(&bytes[index..index + 4])?;
+
+    if is_low_surrogate(code_point) {
+        return Err(JSONPathError::syntax(
+            "unexpected low surrogate code point".to_owned(),
+        ));
+    }
+
+    if is_high_surrogate(code_point) {
+        if !(index + 9 < length && bytes[index + 4] == b'\\' && bytes[index + 5] == b'u') {
+            return Err(JSONPathError::syntax(
+                "incomplete escape sequence".to_owned(),
+            ));
+        }
+
+        let low_surrogate = parse_hex_digits(&bytes[index + 6..index + 10])?;
+
+        if !is_low_surrogate(low_surrogate) {
+            return Err(JSONPathError::syntax("unexpected code point".to_owned()));
+        }
+
+        code_point = 0x10000 + (((code_point & 0x03FF) << 10) | (low_surrogate & 0x03FF));
+        return Ok((code_point, index + 9));
+    }
+
+    Ok((code_point, index + 3))
+}
+
+fn parse_hex_digits(digits: &[u8]) -> Result<u32, JSONPathError> {
+    let s = str::from_utf8(digits).unwrap();
+    u32::from_str_radix(s, 16)
+        .map_err(|_| JSONPathError::syntax("invalid escape sequence".to_owned()))
+}
+
+fn encode_code_point(code_point: u32) -> Result<Vec<u8>, JSONPathError> {
+    if code_point < 0x1F {
+        Err(JSONPathError::syntax("invalid character".to_owned()))
+    } else {
+        // TODO: better
+        let mut buf = [0; 4];
+        let rv = char::from_u32(code_point).unwrap().encode_utf8(&mut buf);
+        Ok(rv.as_bytes().to_owned())
+    }
+}
+
+fn is_high_surrogate(code_point: u32) -> bool {
+    code_point >= 0xD800 && code_point <= 0xDBFF
+}
+
+fn is_low_surrogate(code_point: u32) -> bool {
+    code_point >= 0xDC00 && code_point <= 0xDFFF
+}

--- a/crates/jsonpath_rfc9535_singular_selector/tests/implicit-root-tests.rs
+++ b/crates/jsonpath_rfc9535_singular_selector/tests/implicit-root-tests.rs
@@ -1,0 +1,87 @@
+use jsonpath_rfc9535_singular::find;
+use serde_json::Value;
+
+#[test]
+fn just_a_name() {
+    let data = r#"
+    {
+        "a": "b"
+    }"#;
+
+    let value: Value = serde_json::from_str(data).unwrap();
+    let query = "a";
+    let nodes = find(query, &value).unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().path(), "$['a']");
+    assert_eq!(nodes.first().unwrap().value.as_str().unwrap(), "b");
+}
+
+#[test]
+fn start_with_bracketed_name() {
+    let data = r#"
+    {
+        "a": "b"
+    }"#;
+
+    let value: Value = serde_json::from_str(data).unwrap();
+    let query = "['a']";
+    let nodes = find(query, &value).unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().path(), "$['a']");
+    assert_eq!(nodes.first().unwrap().value.as_str().unwrap(), "b");
+}
+
+#[test]
+fn start_with_bracketed_names() {
+    let data = r#"
+    {
+        "a": "b"
+    }"#;
+
+    let value: Value = serde_json::from_str(data).unwrap();
+    let query = "['a', 'b']";
+    let nodes = find(query, &value).unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().path(), "$['a']");
+    assert_eq!(nodes.first().unwrap().value.as_str().unwrap(), "b");
+}
+
+#[test]
+fn start_with_bracketed_wildcard() {
+    let data = r#"
+    {
+        "a": "b"
+    }"#;
+
+    let value: Value = serde_json::from_str(data).unwrap();
+    let query = "[*]";
+    let nodes = find(query, &value).unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().path(), "$['a']");
+    assert_eq!(nodes.first().unwrap().value.as_str().unwrap(), "b");
+}
+
+#[test]
+fn singular_query_selector() {
+    let data = r#"
+    {
+        "a": {
+            "j": [1, 2, 3],
+            "p": {
+            "q": [4, 5, 6]
+            }
+        },
+        "b": ["j", "p", "q"],
+        "c d": {
+            "x": {
+            "y": 1
+            }
+        }
+    }"#;
+
+    let value: Value = serde_json::from_str(data).unwrap();
+    let query = "a[b[1]]";
+    let nodes = find(query, &value).unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().path(), "$['a']['p']");
+}


### PR DESCRIPTION
This PR makes the root identifier optional in the _jsonpath_rfc9535_singular_ crate, deviating from the standard.

Without an explicit root identifier (`$`) or current node identifier (`@`), a query is assumed to be a root query if it starts with a shorthand name selector or bracketed segment.

This applies to queries, <s>filter queries</s> and singular selector queries.